### PR TITLE
Allow some parameters in data_01.py to be passed as arguments

### DIFF
--- a/LW_MRS/data_01.py
+++ b/LW_MRS/data_01.py
@@ -2,14 +2,51 @@ import nmrglue as ng
 import numpy as np
 import os
 import scipy.io as scio
+import argparse
+from pathlib import Path
+import os.path
 
-train_num_samp = 10000
+parser = argparse.ArgumentParser(description='MRSNet')
+parser.add_argument(
+        '--basedir',
+        type=Path,
+        default='C:/Users/s4548361/Desktop',
+        help='Base directory for input and output data'
+)
+parser.add_argument(
+        '--train_path',
+        type=Path,
+        default='LW_MRS_NOISE_FREE/train_dataset_350_noise_free/',
+        help='Subpath to training data'
+)
+parser.add_argument(
+        '--data_path',
+        type=Path,
+        default='T_10000_350_64/',
+        help='Subpath to training data'
+)
+parser.add_argument(
+        '--mask_path',
+        type=Path,
+        default='T_10000_350_64/',
+        help='Subpath to mask data'
+)
+parser.add_argument(
+        '--train_num_samp',
+        type=int,
+        default=10,
+        help='Number of training samples'
+)
+opt = parser.parse_args()
 
+train_num_samp = opt.train_num_samp
 
-train_path_350 = "C:/Users/s4548361/Desktop/LW_MRS_NOISE_FREE/train_dataset_350_noise_free/"
-mask_path = 'C:/Users/s4548361/Desktop/T_10000_350_64/'
+train_path_350 = os.path.join(opt.basedir,opt.train_path)
 
-data_path = 'C:/Users/s4548361/Desktop/T_10000_350_64/'
+mask_path = os.path.join(opt.basedir,opt.mask_path,'')
+
+data_path = os.path.join(opt.basedir,opt.data_path,'')
+
 if not os.path.exists(train_path_350):
     os.makedirs(train_path_350)
 
@@ -58,19 +95,19 @@ if not os.path.exists(train_path_350):
 #
 #
 #
-#     os.chdir(train_path_350)
+#     os.chdir(opt.train_path_350)
 #     scio.savemat('train_data_' + str(i+1) + '.mat', {'real': np.real(data), 'imag': np.imag(data), 'mask': mask})
 
 for i in range(train_num_samp):
     ### Extract real mask
     _, data = ng.fileio.rnmrtk.read(
-        mask_path + '1D_Time_Full/IN_TF_C_' + str(i+1) + '.sec')
+        os.path.join(mask_path , str('1D_Time_Full/IN_TF_C_' + str(i+1) + '.sec')))
 
     # _, noise_free_data = ng.fileio.rnmrtk.read(
     #     data_path + '1D_Time_Full_NL/IN_TF_C_' + str(i + 1) + '.sec')
 
     _, data_sub = ng.fileio.rnmrtk.read(
-        mask_path + '1D_Time_Subset/IN_TS_C_' + str(i+1) + '.sec')
+        os.path.join(mask_path , str('1D_Time_Subset/IN_TS_C_' + str(i+1) + '.sec')))
 
     mask = data - data_sub
 


### PR DESCRIPTION
Allow the following to be passed as arguments:
  --train_num_samp: number of training samples
  --basedir: root directory for training and output data
  --data_path: path to read in raw training data (relative to basedir)
  --mask_path: path to read in raw mask data  (relative to basedir)
  --train_path: path to write output training data (relative to basedir)
Previous hard-coded values retained as defaults.